### PR TITLE
Fix pinyin tone type to unblock Vercel build

### DIFF
--- a/lib/lib/pinyin.ts
+++ b/lib/lib/pinyin.ts
@@ -1,2 +1,3 @@
 import { pinyin } from 'pinyin-pro'
-export const toPinyin = (txt:string) => pinyin(txt, { toneType: 'mark' })
+// Use supported "symbol" tone type; "mark" is deprecated and caused build errors.
+export const toPinyin = (txt: string) => pinyin(txt, { toneType: 'symbol' })

--- a/lib/pinyin.ts
+++ b/lib/pinyin.ts
@@ -1,2 +1,5 @@
 import { pinyin } from 'pinyin-pro'
-export const toPinyin = (txt:string) => pinyin(txt, { toneType: 'mark' })
+// Use the supported option "symbol" for toneType to add tone marks.
+// The previous value "mark" is not recognized by the current typings and
+// caused the build to fail on Vercel.
+export const toPinyin = (txt: string) => pinyin(txt, { toneType: 'symbol' })


### PR DESCRIPTION
## Summary
- use supported `symbol` tone type in pinyin utility to avoid build errors

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898e4e03a88832cba8678b5db7ecb57